### PR TITLE
Fix: Encoding Inner Text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 dist
 node_modules
-test*
+test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist
 node_modules
+test*

--- a/src/voxxml/voxxml.ts
+++ b/src/voxxml/voxxml.ts
@@ -20,7 +20,7 @@ export class VoxXML {
     }
     let node = this.element.ele(name, attributes)
     if (text) {
-      //If the text includes tags, parse as XML, not text
+      //If the text includes tags, parse as XML
       const hasTags = /<[a-z][\s\S]*>/i.test(text)
       if (hasTags) {
         const xmlFragment = fragment(text)

--- a/src/voxxml/voxxml.ts
+++ b/src/voxxml/voxxml.ts
@@ -20,8 +20,8 @@ export class VoxXML {
     }
     let node = this.element.ele(name, attributes)
     if (text) {
-      //If the text includes tags, parse as XML
-      const hasTags = /<[a-z][\s\S]*>/i.test(text)
+      // If the text includes tags, parse as XML
+      const hasTags = /<[^>]+>/.test(text)
       if (hasTags) {
         const xmlFragment = fragment(text)
         node.import(xmlFragment)

--- a/src/voxxml/voxxml.ts
+++ b/src/voxxml/voxxml.ts
@@ -1,3 +1,4 @@
+import { fragment } from 'xmlbuilder2'
 import { XMLBuilder } from 'xmlbuilder2/lib/interfaces'
 
 /**
@@ -17,16 +18,25 @@ export class VoxXML {
       text = attributes
       attributes = undefined
     }
-
     let node = this.element.ele(name, attributes)
-    if (text) node = node.txt(text as string)
+    if (text) {
+      //If the text includes tags, parse as XML, not text
+      const hasTags = /<[a-z][\s\S]*>/i.test(text)
+      if (hasTags) {
+        const xmlFragment = fragment(text)
+        node.import(xmlFragment)
+        return node
+      }
+
+      node.txt(text)
+    }
 
     return node
   }
 
   /**
    * Export the VoxXML as a string
-   * 
+   *
    * @param beautify if true, formats the XML string with line breaks and indentation
    * @returns stringified XML
    */
@@ -36,7 +46,7 @@ export class VoxXML {
 
   /**
    * Adds a comment to the current VoxXML element
-   * 
+   *
    * @param text the text in the comment
    */
   comment(text: string): void {


### PR DESCRIPTION
Fixes the encoding for inner text on tags to support xml tags

This supports usage like: 
```
const response = new VoiceResponse()

response.say('<speak>Some text <say-as interpret-as="digits">12345</say-as></speak>')

console.log(response.toString()) //<?xml version="1.0" encoding="UTF-8"?><Response><Say><speak>Some text <say-as interpret-as="digits">12345</say-as></speak></Say></Response>
```